### PR TITLE
feat: Refactor DockerComposePublishingContext for clarity

### DIFF
--- a/src/Aspire.Hosting.Docker/DockerComposePublisherOptions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposePublisherOptions.cs
@@ -19,4 +19,9 @@ public sealed class DockerComposePublisherOptions : PublishingOptions
     /// The name of an existing network to be used.
     /// </summary>
     public string? ExistingNetworkName { get; set; }
+
+    /// <summary>
+    /// Indicates whether to build container images during the publishing process.
+    /// </summary>
+    public bool BuildImages { get; set; } = true;
 }


### PR DESCRIPTION
## Description

Pull request changes include adding a new option to control the image building process during publishing, ensuring that image building only occurs when explicitly enabled. Between a rebuild, probably don't need to rebuild all Project containers if someone has just say changed a Container resource image tag.

These changes aim to streamline the publishing process and improve the overall developer experience. The refactor also includes adjustments to existing tests to accommodate the new functionality and ensure that all scenarios are covered.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No